### PR TITLE
Make `make STATIC=1 install` succeed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ SOURCES = gpc.h gpc.c gpcml.c $(foreach x,$(MODS),$(x).ml $(x).mli)
 RESULT = camlgpc
 
 LIBINSTALL_FILES = camlgpc.a camlgpc.cma camlgpc.cmxa libcamlgpc_stubs.a \
-dllcamlgpc_stubs.* \
-$(foreach x,$(MODS),$x.mli) $(foreach x,$(MODS),$x.cmi)
+$(foreach x,$(MODS),$x.mli) $(foreach x,$(MODS),$x.cmi) \
+-optional dllcamlgpc_stubs.* 
 
 OCAMLNCFLAGS = -g
 OCAMLBCFLAGS = -g


### PR DESCRIPTION
This is necessary on platforms without shared libraries, e.g. iOS.
